### PR TITLE
Improve k-fold on Metadata

### DIFF
--- a/src/deep_audio_dataset/dataset.py
+++ b/src/deep_audio_dataset/dataset.py
@@ -1,6 +1,5 @@
 """Basic Audio Dataset classes."""
 from abc import ABC, abstractmethod
-from datetime import datetime
 from functools import partial
 from itertools import chain
 import json
@@ -396,10 +395,7 @@ class BaseAudioDataset(ABC):
             result = tf.io.parse_single_example(x, feature_description)
             return result['index'], result['a_in'], result['a_out']
 
-        if self._shuffle_size is None:
-            shuffle_size = max(int(0.1 * self.num_examples), 1000)
-        else:
-            shuffle_size = self._shuffle_size
+        shuffle_size = max(int(0.1 * self.num_examples), 1000) if self._shuffle_size is None else self._shuffle_size
 
         result = tf.data.TFRecordDataset(self.tfrecord_path)
 

--- a/src/deep_audio_dataset/dataset.py
+++ b/src/deep_audio_dataset/dataset.py
@@ -74,10 +74,14 @@ class BaseAudioDataset(ABC):
         if generate_tfrecords:
             self._ensure_tfrecords_exist()
 
-    def all(self) -> tf.data.Dataset:
+    def all(self) -> tf.data.Dataset:  # noqa: A003
+        """Return the entire dataset as a tf.data.Dataset.
+
+        Returns:
+            Dataset: The entire dataset.
+        """
         raw_ds = self._load_raw_ds()
-        filtered_ds = self._generate_filtered_ds(raw_ds, list(range(self.num_examples)))
-        return filtered_ds
+        return self._generate_filtered_ds(raw_ds, list(range(self.num_examples)))
 
     def train_test_split(
         self,

--- a/src/deep_audio_dataset/dataset.py
+++ b/src/deep_audio_dataset/dataset.py
@@ -74,6 +74,11 @@ class BaseAudioDataset(ABC):
         if generate_tfrecords:
             self._ensure_tfrecords_exist()
 
+    def all(self) -> tf.data.Dataset:
+        raw_ds = self._load_raw_ds()
+        filtered_ds = self._generate_filtered_ds(raw_ds, list(range(self.num_examples)))
+        return filtered_ds
+
     def train_test_split(
         self,
         train_size: Optional[float] = None,

--- a/src/deep_audio_dataset/dataset.py
+++ b/src/deep_audio_dataset/dataset.py
@@ -397,7 +397,7 @@ class BaseAudioDataset(ABC):
 
         shuffle_size = max(int(0.1 * self.num_examples), 1000) if self._shuffle_size is None else self._shuffle_size
 
-        result = tf.data.TFRecordDataset(self.tfrecord_path)
+        result = tf.data.TFRecordDataset(self.tfrecord_path).map(_parser)
 
         if shuffle_size:
             result = result.shuffle(
@@ -405,7 +405,7 @@ class BaseAudioDataset(ABC):
                 reshuffle_each_iteration=False  # this must be false, otherwise the X and y sets will not stay coupled
             )
 
-        return result.map(_parser)
+        return result
 
     def _generate_filtered_ds(self, raw_ds: tf.data.Dataset, indices: List[int]) -> tf.data.Dataset:
         def _split(_: tf.Tensor, a_in: tf.Tensor, a_out: tf.Tensor, i: int) -> tf.Tensor:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -204,11 +204,9 @@ def test_multilabel_classification_two_samples(tmp_path):
     with open(f"{tmp_path}/test.txt", "w") as f:
         f.write("test0.wav,01\ntest1.wav,10")
 
-
     dataset = MultilabelClassificationAudioDataset(tmp_path, "test.txt")
     dataset._ensure_tfrecords_exist()
-    actual_results = [(x, y) for x, y in dataset.all().as_numpy_iterator()]
-    actual_results = sorted(actual_results, key=lambda x: x[0][0])
+    actual_results = sorted(dataset.all().as_numpy_iterator(), key=lambda x: x[1][0])
 
     assert len(actual_results) == 2
     assert all(actual_results[0][1] == [0.0, 1.0])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -31,8 +31,8 @@ def test_audio_dataset_generate(two_wav_files):
     base_path = two_wav_files[1]
     ad = AudioDataset(f"{base_path}/test_data", "test.txt")
 
-    ad._ensure_generated_records_directory()
-    ds = ad._save_generated_dataset("test", [i for i in range(2)])
+    ad._ensure_tfrecords_exist()
+    ds = ad.all()
 
     for x, y in ds.as_numpy_iterator():
         assert len(x) == 441000
@@ -164,8 +164,8 @@ def test_multilabel_classification(tmp_path):
 
 
     dataset = MultilabelClassificationAudioDataset(tmp_path, "test.txt")
-    dataset._ensure_generated_records_directory()
-    actual_results = [(x, y) for x, y in dataset._save_generated_dataset("test", [i for i in range(1)]).as_numpy_iterator()]
+    dataset._ensure_tfrecords_exist()
+    actual_results = [(x, y) for x, y in dataset.all().as_numpy_iterator()]
 
     assert len(actual_results) == 1
     assert list(actual_results[0][1]) == [1.0]
@@ -183,8 +183,8 @@ def test_multilabel_classification_two_labels(tmp_path):
 
 
     dataset = MultilabelClassificationAudioDataset(tmp_path, "test.txt")
-    dataset._ensure_generated_records_directory()
-    actual_results = [(x, y) for x, y in dataset._save_generated_dataset("test", [i for i in range(1)]).as_numpy_iterator()]
+    dataset._ensure_tfrecords_exist()
+    actual_results = [(x, y) for x, y in dataset.all().as_numpy_iterator()]
 
     assert len(actual_results) == 1
     assert all(actual_results[0][1] == [0.0, 1.0])
@@ -206,8 +206,8 @@ def test_multilabel_classification_two_samples(tmp_path):
 
 
     dataset = MultilabelClassificationAudioDataset(tmp_path, "test.txt")
-    dataset._ensure_generated_records_directory()
-    actual_results = [(x, y) for x, y in dataset._save_generated_dataset("test", [i for i in range(2)]).as_numpy_iterator()]
+    dataset._ensure_tfrecords_exist()
+    actual_results = [(x, y) for x, y in dataset.all().as_numpy_iterator()]
     actual_results = sorted(actual_results, key=lambda x: x[0][0])
 
     assert len(actual_results) == 2
@@ -295,7 +295,7 @@ def test_regression_dataset(tmp_path):
     dataset = RegressionAudioDataset(tmp_path, "test.txt")
     assert dataset.n_ == 2
 
-    actual_results = [(x, y) for x, y in dataset._save_generated_dataset("test", [i for i in range(1)]).as_numpy_iterator()]
+    actual_results = [(x, y) for x, y in dataset.all().as_numpy_iterator()]
 
     assert len(actual_results) == 1
     assert all(actual_results[0][1] == [1.0, 0.0])


### PR DESCRIPTION
This PR improves the k-folding on metadata by using the newer technique involving static hash tables. This PR also includes several code cleanups of private methods, test clean ups, and test refactors. Additionally, an `all` method was added that allows for the user to iterate over the entire dataset as it is.